### PR TITLE
remove extra letters, add proper Skolt palatalizer

### DIFF
--- a/build/tab-sami.html
+++ b/build/tab-sami.html
@@ -1,107 +1,98 @@
-<html><head></head><body><h1 class="fi">Saame</h1>
-<h1 class="sv">Samiska</h1>
+<html>
 
-<h2 class="fi">Erikoismerkit</h2>
-<h2 class="sv">Specialtecken</h2>
+<head></head>
 
-<p class="fi">Huom. Voit kopioida merkin leikepöydälle klikkaamalla sitä.</p>
-<p class="sv">Obs. Du kan kopiera tecken genom att klicka på den.</p>
+<body>
+  <h1 class="fi">Saame</h1>
+  <h1 class="sv">Samiska</h1>
 
-<div class="scrollwrap">
+  <h2 class="fi">Erikoismerkit</h2>
+  <h2 class="sv">Specialtecken</h2>
+
+  <p class="fi">Huom. Voit kopioida merkin leikepöydälle klikkaamalla sitä.</p>
+  <p class="sv">Obs. Du kan kopiera tecken genom att klicka på den.</p>
+
+  <div class="scrollwrap">
     <p class="note fi">Käytä saamen kirjoittamiseen pohjoissaamen näppäimistöä. Tarvittaessa voit kopioida merkkejä alta.</p>
     <p class="note sv">För att skriva samiska, använd tangentbordet för nordsamiska. Vid behov, kopiera tecken nedan.</p>
     <table class="borderless">
-        <tbody><tr>
-            <td>
-                <div class="key clickable"><span>á</span></div>
-                <div class="key clickable"><span>Á</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>š</span></div>
-                <div class="key clickable"><span>Š</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ŧ</span></div>
-                <div class="key clickable"><span>Ŧ</span></div>
-            </td>
-            <td>
-                <div class="key clickable"><span>ï</span></div>
-                <div class="key clickable"><span>Ï</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>õ</span></div>
-                <div class="key clickable"><span>Õ</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ŋ</span></div>
-                <div class="key clickable"><span>Ŋ</span></div>
-            </td></tr>
+      <tbody>
         <tr>
-            <td><div class="key clickable"><span>â</span></div>
-                <div class="key clickable"><span>Â</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ǧ</span></div>
-                <div class="key clickable"><span>Ǧ</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ǥ</span></div>
-                <div class="key clickable"><span>Ǥ</span></div>
-            </td>
-            <td><div class="key clickable"><span>ǩ</span></div>
-                <div class="key clickable"><span>Ǩ</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ø</span></div>
-                <div class="key clickable"><span>Ø</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>æ</span></div>
-                <div class="key clickable"><span>Æ</span></div>
-            </td></tr>
+          <td>
+            <div class="key clickable"><span>á</span></div>
+            <div class="key clickable"><span>Á</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>š</span></div>
+            <div class="key clickable"><span>Š</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>ŧ</span></div>
+            <div class="key clickable"><span>Ŧ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>õ</span></div>
+            <div class="key clickable"><span>Õ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>ŋ</span></div>
+            <div class="key clickable"><span>Ŋ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>â</span></div>
+            <div class="key clickable"><span>Â</span></div>
+          </td>
+        </tr>
         <tr>
-            <td><div class="key clickable"><span>đ</span></div>
-                <div class="key clickable"><span>Đ</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ž</span></div>
-                <div class="key clickable"><span>Ž</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ǯ</span></div>
-                <div class="key clickable"><span>Ǯ</span></div>
-            </td>
-            <td><div class="key clickable"><span>ʒ</span></div>
-                <div class="key clickable"><span>Ʒ</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>č</span></div>
-                <div class="key clickable"><span>Č</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ǩ</span></div>
-                <div class="key clickable"><span>Ǩ</span></div>
-            </td></tr>
+          <td>
+            <div class="key clickable"><span>ǧ</span></div>
+            <div class="key clickable"><span>Ǧ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>ǥ</span></div>
+            <div class="key clickable"><span>Ǥ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>ǩ</span></div>
+            <div class="key clickable"><span>Ǩ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>đ</span></div>
+            <div class="key clickable"><span>Đ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>ž</span></div>
+            <div class="key clickable"><span>Ž</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>ǯ</span></div>
+            <div class="key clickable"><span>Ǯ</span></div>
+          </td>
+        </tr>
         <tr>
-            <td><div class="key clickable"><span>þ</span></div>
-                <div class="key clickable"><span>Þ</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ç</span></div>
-                <div class="key clickable"><span>Ç</span></div>
-                </td>
-				<td>
-                <div class="key clickable"><span>ð</span></div>
-                <div class="key clickable"><span>Ð</span></div>
-				</td>
-				<td>
-				<div class="key clickable"><span>µ</span></div>
-                <div class="key clickable"><span>ƒ</span></div>
-				</td>
-				<td>
-                <div class="key clickable"><span>ʔ</span></div>
-                <div class="key clickable"><span>ß</span></div>
-            </td></tr>
-    </tbody></table>
-</div>
-</body></html>
+          <td>
+            <div class="key clickable"><span>ʒ</span></div>
+            <div class="key clickable"><span>Ʒ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>č</span></div>
+            <div class="key clickable"><span>Č</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>ǩ</span></div>
+            <div class="key clickable"><span>Ǩ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>µ</span></div>
+            <div class="key clickable"><span>ƒ</span></div>
+          </td>
+          <td>
+            <div class="key clickable"><span>ˊ</span></div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
ï, ø, æ, þ, ç and ð are not used in the orthographies of any Sámic language used in Finland. Can't see the point of having ß and ʔ, either. Added ˊ which is the proper palatalization mark in Skolt Sámic. Also beautified code, it looked terrible