### PR TITLE
leaflet attribution, leaflet will-change warning fix

### DIFF
--- a/common/css/leaflet.css
+++ b/common/css/leaflet.css
@@ -1,0 +1,7 @@
+/* Get rid of firefox warning Will-change memory consumption is too high */
+/* Follow up if needed when Firefox is upgraded from ESR 78.3.0 */
+
+.leaflet-fade-anim .leaflet-tile,
+.leaflet-zoom-anim .leaflet-zoom-animated {
+  will-change: auto !important;
+}

--- a/content/index.html
+++ b/content/index.html
@@ -5,9 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta charset="UTF-8" />
     <title>Koeympäristön ohjeet / Provmiljöns instruktioner</title>
+    <link rel="icon" href="../common/images/favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="../common/css/tab.css" type="text/css" media="screen" />
     <link rel="stylesheet" href="../common/css/tocbot.css" type="text/css" />
     <link rel="stylesheet" href="../common/css/search.css" type="text/css" />
+    <link rel="stylesheet" href="../common/css/leaflet.css" type="text/css" />
     <script type="text/javascript" src="./bundle.js"></script>
   </head>
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="common/css/NotoSerif.css" type="text/css" media="screen" />
     <link rel="stylesheet" href="common/css/tab.css" type="text/css" media="screen" />
     <link rel="stylesheet" href="common/css/landing_page.css" type="text/css" media="screen" />
+    <link rel="stylesheet" href="common/css/leaflet.css" type="text/css" media="screen" />
   </head>
   <body>
     <div id="tab-container">

--- a/src/tabs/geography.ts
+++ b/src/tabs/geography.ts
@@ -5,6 +5,7 @@ import './geography.css'
 import 'leaflet/dist/leaflet.css'
 
 const mapTilesUrl = process.env.MAP_TILES_URL
+
 const setupWorldMap = () => {
   const mapUrlSv = `${mapTilesUrl}/world/sv/{z}/{x}/{y}.png`
   const mapUrlFi = `${mapTilesUrl}/world/fi/{z}/{x}/{y}.png`
@@ -16,6 +17,7 @@ const setupWorldMap = () => {
     createWorldMap({
       container: mapContainer,
       mapUrl,
+      attribution: '&copy; Leaflet OpenStreetMap',
     })
   }
 }
@@ -28,6 +30,7 @@ const setupTerrainMap = () => {
     createTerrainMap({
       container: mapContainer,
       mapUrl,
+      attribution: '&copy; Leaflet Maanmittauslaitos',
     })
   }
 }


### PR DESCRIPTION
-kartta-attribuution korvaaminen oikeilla
-Leafletin aiheuttama will-change varoituksen korjaus busterin Firefox-versiossa
-Mergataan tämä sitten  kun https://github.com/digabi/maps/pull/40 korjattu ja mergattu
