### PR TITLE
use public math image renderer in dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Kokeissa käytettävä versio ohjeesta löytyy osoitteesta https://cheat.abitti.
 Projektin kehitystä varten tarvitset Yarn paketinhallintatyökalun https://yarnpkg.com/ sekä Node.js version 12 https://nodejs.org/en/ (tarkempi versio löytyy `.nvmrc` tiedostosta)
 
 1. Asenna projektin riippuvuudet komennolla `yarn install`
-2. Generoi HTML tiedostot komennolla `yarn build`
+2. Generoi HTML tiedostot komennolla `yarn build:internet` (varsinaisen koetilanteen versio käyttää `yarn build`)
 3. Tämän jälkeen voit ajaa projektia lokaalisti komennolla `yarn start`. Lokaalin koe-ohjeen löydät osoitteesta http://localhost:8080
 
-TypeScript muutokset näkyvät selaimessa automaattisesti kun projekti on käynnissä. Jotta HTML tiedostojen muutokset tulevat näkyviin, pitää ne generoida uudelleen `yarn build` komennolla.
+TypeScript muutokset näkyvät selaimessa automaattisesti kun projekti on käynnissä. Jotta HTML tiedostojen muutokset tulevat näkyviin, pitää ne generoida uudelleen `yarn build:internet` komennolla.
 
 ## Ohjeet muutosten ehdottamiseen
 

--- a/src/tabs/common/clipboard.ts
+++ b/src/tabs/common/clipboard.ts
@@ -39,16 +39,6 @@ const copyText = (event: MouseEvent) => {
     })
 }
 
-const getMathDemoUrl = () => {
-  switch (window.location.hostname) {
-    case 'cheat.abitti.fi':
-    case 'cheat.test.abitti.fi':
-      return 'https://math-demo.abitti.fi'
-    default:
-      return ''
-  }
-}
-
 let selectedEquation: HTMLElement
 const copyEquation = (event: MouseEvent) => {
   const target = event.target as HTMLElement
@@ -67,7 +57,7 @@ const copyEquation = (event: MouseEvent) => {
 
   const mathImage = document.createElement('img')
   mathImage.setAttribute('alt', latex)
-  mathImage.setAttribute('src', `${getMathDemoUrl()}/math.svg?latex=${encodeURIComponent(latex)}`)
+  mathImage.setAttribute('src', `${process.env.MATH_DEMO_URL}/math.svg?latex=${encodeURIComponent(latex)}`)
   document.body.appendChild(mathImage)
   const range = document.createRange()
   range.selectNode(mathImage)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,8 @@ module.exports = (env, argv) => {
           process.env.DEPLOYMENT_ENV === 'koe'
             ? JSON.stringify('http://localhost/tiles')
             : JSON.stringify('https://s3.eu-north-1.amazonaws.com/maptiles-cheat.abitti.fi-cheat.abitti-test'),
+        'process.env.MATH_DEMO_URL':
+          process.env.DEPLOYMENT_ENV === 'koe' ? JSON.stringify('') : JSON.stringify('https://math-demo.abitti.fi'),
       }),
     ],
     output: {


### PR DESCRIPTION
-käytetään debian-buildissa kaavojen kopionnissa kokelaan koneen kaavan renderöintiä-API:a, muulloin kun on netti käytössä julkista URL:ia