### PR TITLE
Avoid losing the Python code

### DIFF
--- a/content/tab-programming.html
+++ b/content/tab-programming.html
@@ -6,8 +6,11 @@
 
     <div id="code-editor"></div>
 
-    <button class="code-editor-execute fi">Suorita ohjelma</button>
-    <button class="code-editor-execute sv">Kör program</button>
+    <button class="code-editor-button code-editor-execute fi">Suorita ohjelma</button>
+    <button class="code-editor-button code-editor-execute sv">Kör program</button>
+
+    <button class="code-editor-button code-editor-copy fi">Kopioi leikepöydälle</button>
+    <button class="code-editor-button code-editor-copy sv">Kopiera till urklippet</button>
 
     <p class="fi">Tulosteet / virheet:</p>
     <p class="sv">Utskrift / felen:</p>
@@ -24,6 +27,7 @@
   <li>Voit kopioida lähdemateriaalissa olevia ohjelmakoodeja leikepöydälle klikkaamalla haluamaasi esimerkkikoodia.</li>
   <li>Liitä leikepöydälle kopioimasi koodi klikkaamalla ohjelmakoodi-ikkunaa ja painamalla ctrl-v.</li>
   <li>Suorita ohjelmakoodi-ikkunassa oleva koodi klikkaamalla Suorita ohjelma -painiketta.</li>
+  <li>Ohjelmakoodi-ikkunaa ei varmuuskopioida. Kopioi ohjelmakoodisi koesuoritukseen mahdollisimman usein.</li>
 </ul>
 
 <h2 class="fi">Tekstin tulostaminen</h2>

--- a/src/tabs/common/clipboard.ts
+++ b/src/tabs/common/clipboard.ts
@@ -39,10 +39,7 @@ const copyText = (event: MouseEvent) => {
     })
 }
 
-const copyCode = (event: MouseEvent) => {
-  const target = event.target as HTMLElement
-  const text = target.textContent
-
+export const setCodeToClipboard = (text: string) => {
   copyTextToClipboard(text)
     .then(() => {
       showSuccess('copying_box_code')
@@ -50,6 +47,11 @@ const copyCode = (event: MouseEvent) => {
     .catch(() => {
       alert('Copying to clipboard is not supported on your browser.')
     })
+}
+
+const copyCode = (event: MouseEvent) => {
+  const target = event.target as HTMLElement
+  setCodeToClipboard(target.textContent)
 }
 
 let selectedEquation: HTMLElement

--- a/src/tabs/common/monaco-editor.ts
+++ b/src/tabs/common/monaco-editor.ts
@@ -26,6 +26,7 @@ export const initializeMonacoEditor = (codeEditorId: string) => {
   editor = monaco.editor.create(document.getElementById(codeEditorId), {
     automaticLayout: true,
   	language: 'python',
+    lineNumbersMinChars: 2,
     minimap: {
       enabled: false,
     },

--- a/src/tabs/common/monaco-editor.ts
+++ b/src/tabs/common/monaco-editor.ts
@@ -4,7 +4,6 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 import 'monaco-editor/esm/vs/basic-languages/python/python.contribution.js';
 
 var editor: monaco.editor.IStandaloneCodeEditor
-var lastCode = ""
 
 declare global {
   interface Window {
@@ -16,6 +15,20 @@ self.MonacoEnvironment = {
 	getWorkerUrl: function (moduleId, label) {
 		return './editor.worker.bundle.js'
 	}
+}
+
+const setLastCode = (code: string) => {
+  if (window.localStorage) {
+    window.localStorage.setItem('monaco-editor-lastcode', code)
+  }
+}
+
+const getLastCode = (): string => {
+  if (window.localStorage && window.localStorage.getItem('monaco-editor-lastcode')) {
+    return window.localStorage.getItem('monaco-editor-lastcode')
+  }
+
+  return ""
 }
 
 export const getCode = () => {
@@ -33,12 +46,12 @@ export const initializeMonacoEditor = (codeEditorId: string) => {
     scrollBeyondLastLine: false,
     tabSize: 3,
     renderWhitespace: 'all',
-		value: lastCode,
+		value: getLastCode(),
     wordWrap: 'on',
   })
 
 	document.getElementById(codeEditorId).addEventListener('keyup', () => {
-		lastCode = editor.getValue()
+		setLastCode(editor.getValue())
 	})
 
 	document.getElementById("tab-programming-ide-container").addEventListener('replaceEditorTextForTestingPurposes', (event) => {

--- a/src/tabs/programming.css
+++ b/src/tabs/programming.css
@@ -35,7 +35,7 @@
   padding: 5px;
 }
 
-.code-editor-execute {
+.code-editor-button {
   background-color: #1E5075;
   padding: 10px;
   color: #fff;
@@ -44,7 +44,7 @@
   margin: 10px 0 10px;
 }
 
-.code-editor-execute:hover, .code-editor-execute:active {
+.code-editor-button:hover, .code-editor-button:active {
   padding: 10px;
   background-color: #359BB7;
 }

--- a/src/tabs/programming.ts
+++ b/src/tabs/programming.ts
@@ -1,10 +1,12 @@
 import './programming.css'
 import { initializeMonacoEditor, getCode } from './common/monaco-editor'
+import { setCodeToClipboard } from './common/clipboard'
 
 const codeEditorId = 'code-editor'
 const outputId = 'code-output'
 const errorId = 'code-error'
 const executeButtonSelector = '.code-editor-execute'
+const copyCodeToClipboardButtonSelector = '.code-editor-copy'
 const boilerplateErrorstrings = [
   {
     errorString: 'PythonError: Traceback \\(most recent call last\\)[.,:"=\\-_\\/\\(\\)\\|\\n\\s\\w]+(File "<exec>")',
@@ -85,6 +87,10 @@ const executeCode = () => {
   }
 }
 
+const copyCodeToClipboard = () => {
+  setCodeToClipboard(getCode())
+}
+
 const getUrlPath = () => {
   const pathname = window.location.pathname
   return pathname.replace(/build\/.*$/, '')
@@ -124,4 +130,7 @@ export const initializeProgrammingTab = () => {
 
   const executeButtons = Array.from(document.querySelectorAll(executeButtonSelector))
   executeButtons.forEach((element) => element.addEventListener('click', executeCode))
+
+  const copyToClipboardButtons = Array.from(document.querySelectorAll(copyCodeToClipboardButtonSelector))
+  copyToClipboardButtons.forEach((element) => element.addEventListener('click', copyCodeToClipboard))
 }


### PR DESCRIPTION
 * Added button and help text for copying Python code to exam editor
 * Store Python code to `window.localStorage`
 * Bonus: Make Monaco editor line number column more narrow to save horisontal space