### PR TITLE
Invalidate Cloudfront on deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -44,3 +44,5 @@ jobs:
           cp -r index.html accessibility-fi.html accessibility-sv.html release/
       - name: Sync release files into the test bucket
         run: aws s3 sync release/ s3://${{ secrets.PROD_DEPLOY_BUCKET_NAME }}
+      - name: Invalidate Cloudfront
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.PROD_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -44,3 +44,5 @@ jobs:
           cp -r index.html accessibility-fi.html accessibility-sv.html release/
       - name: Sync release files into the test bucket
         run: aws s3 sync release/ s3://${{ secrets.TEST_DEPLOY_BUCKET_NAME }}
+      - name: Invalidate Cloudfront
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.TEST_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
* The Cloudfront distribution IDs have been added to repo secrets
* Atm unknown whether the effective AWS user has rights to make the invalidation