### PR TITLE
Merge stdin, stdout and stderr to better imitate a standard terminal

### DIFF
--- a/content/tab-programming.html
+++ b/content/tab-programming.html
@@ -18,7 +18,6 @@
     </div>
 
     <pre id="code-output" class="code-output-clickable" tabindex="0"></pre>
-    <pre id="code-error" class="code-output-clickable" tabindex="0"></pre>
   </div>
 
   <div id="tab-programming-doc-container">

--- a/src/tabs/programming.css
+++ b/src/tabs/programming.css
@@ -6,23 +6,14 @@
   overflow: auto;
 }
 
-#code-output, #code-error {
+#code-output {
   min-height: 3em;
   display: block;
   overflow-x: auto;
   overflow-y: auto;
   padding: 5px;
   resize: vertical;
-}
-
-#code-output {
   background-color: lightgrey;
-}
-
-#code-error {
-  border-color: red;
-  border-width: 2px;
-  border-style: solid;
 }
 
 #tab-programming-ide-container {
@@ -79,6 +70,12 @@
     top: 0;
     left: 0;
   }
+}
+
+.code-error {
+  border-color: red;
+  border-width: 2px;
+  border-style: solid;
 }
 
 .code-clickable {

--- a/src/tabs/programming.ts
+++ b/src/tabs/programming.ts
@@ -203,7 +203,9 @@ const initializePythonEngine = async () => {
 
   // pyodide is imported by content/index.html
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-  pyodide.runPython('from digabi import input\n__builtins__.input = input') // Load our custom javascript input function and override it as builtin.
+  pyodide.runPython('import builtins\nimport digabi\nbuiltins.input = digabi.input\ndel builtins, digabi')
+  // Load our custom javascript input function and override it as builtin.
+  // Unbind builtins and digabi so that, to the user, the environment looks like new.
 
   setMonacoReadOnly(false)
   showOutput()

--- a/src/tabs/programming.ts
+++ b/src/tabs/programming.ts
@@ -178,7 +178,7 @@ const initializePythonEngine = async () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     pyodide = await loadPyodide({
       indexURL: `${getUrlPath()}common/pyodide/`, // Pydiode does not handle .. as part of the path
-      stdin: () => prompt('Enter input string'), // This should very rarely run since we override the builtin input function
+      stdin: () => prompt('Enter stdin text'), // This should very rarely run since we override the builtin input function
       stdout: (text: string) => printStdout(text),
       stderr: (text: string) => printStderr(text),
     })

--- a/src/tabs/programming.ts
+++ b/src/tabs/programming.ts
@@ -102,9 +102,12 @@ const printStderr = (text: string, printEvenPyodideIsInitializing?: boolean) => 
 const printStdout = (text: string) => printOutput(text)
 
 const digabiPythonModule = {
+  // By far the easiest way to get coloured input messages to the output was to use JavaScript
+  // as the output cannot be formatted in Python without some dirty code and crazy hacks.
+  // This module can be used to expose other functionality to the user in the future.
   input: (__prompt: any = '') => {
     // HACK: Call object's __str__ method instead of using .toString() as Pyodide's .toString() calls __repr__ which is incorrect behaviour for input()
-    // Fallback on .toString() since some Pyodide objects don't seem to have a __str__ function.
+    // Fallback on .toString() since some Pyodide objects don't seem to have a __str__ function (notably str itself).
     const promptText: string = __prompt.__str__ ? __prompt.__str__() : __prompt.toString()
 
     const inputText = prompt(promptText)

--- a/src/tabs/programming.ts
+++ b/src/tabs/programming.ts
@@ -252,7 +252,7 @@ const processAccessibilityKeybindings = (event: KeyboardEvent) => {
       setCodeToClipboard(el.innerText)
       return
     }
-    if (['code-output'].includes(el.id)) {
+    if ('code-output' === el.id) {
       setCodeOutputToClipboard(el.innerText)
       return
     }

--- a/src/tabs/programming.ts
+++ b/src/tabs/programming.ts
@@ -103,12 +103,11 @@ const printStdout = (text: string) => printOutput(text)
 
 const digabiPythonModule = {
   input: (__prompt: any = '') => {
-    // HACK: Call object's __str__ method instead of using .toString() as Pyodide's .toString() calls __repr__
-    // This behaviour mimics the builtin input more closely.
-    const promptText = __prompt.__str__()
+    // HACK: Call object's __str__ method instead of using .toString() as Pyodide's .toString() calls __repr__ which is incorrect behaviour for input()
+    // Fallback on .toString() since some Pyodide objects don't seem to have a __str__ function.
+    const promptText: string = __prompt.__str__ ? __prompt.__str__() : __prompt.toString()
 
     const inputText = prompt(promptText)
-
     if (inputText == null) {
       throw 'Input operation cancelled.'
     }


### PR DESCRIPTION
> [!IMPORTANT]
> This is a draft PR as there still are some problems yet to be resolved. See [Unresolved Problems](#unresolved-problems) for more info.

resolves #692 
resolves #693 

## Implementation Details
Usually I wouldn't explain the implementation, but I felt it was necessary due to the sheer amount of changes made.

### General
The separate code-error element was removed and errors were redirected to the code-output element. The differentiation between stdout and stderr was removed and the code output is now just referenced as output. A colour can now be passed when printing an output which is currently used by stderr and input().

### Stderr
As stdin and stderr is now consolidated to a single place, stderr has very little custom functionality over the standard stdout.
When a stderr message is printed, the code-output element is tagged as errored by adding a custom class to it. CSS will detect this class and format the output with a red border.
The message of stderr is forwarded to output with a red colour.

### Stdin/input
The digabi's input() function was reworked to be more in-line with Python's inbuilt input(). This new function will override Python's default input() using the builtins module. All imports from overriding input() are now cleaned as well.
As we override the function in the builtins module, this forbids the user from using Python's builtin input(), but I felt that this wasn't such big of a problem as long as we can stick as close as possible to Python's default input() behaviour.

The new input() function behaves correctly when translating objects into prompts by using \_\_str\_\_ instead of \_\_repr\_\_ and writes the input _prompt + value_ onto the output as blue.
Blue was chosen as from my limited research, it seemed to be the most distinct colour compared with error's red for people with colour blindness.

The new input() also raises an error when cancelled (we detect when prompt returns null) instead of returning None incorrectly. The error message looks kind of daunting and ugly since it's propagated from JavaScript. It can be looked into whether we can directly raise (against input()'s spec) a Python exception instead if the change is necessary. I personally think that the current format is _good enough_ to be rolled out and can be changed later if needed.

To be able to pass this input() JavaScript function into Python, a custom digabi module was necessary. This module can be used in the future to expose more JavaScript functionality to the user if needed.

While input now skips stdin, there are still situations where stdin might be used (`fileinput` module for example). In these cases, we fall back on a basic JS prompt with a default message.

Input skipping stdin means that redirecting stdin does not work for input(),
but I don't see this as a problem since that functionality has never existed in digabi and I cannot come up with a scenario where one would run into the need to redirect stdin in digabi/Abitti if it's even possible.

## Differences Comparison
### Previously raised issues
<details>
<summary>input() missing from output (#693)</summary>

![image](https://github.com/digabi/koe-ohje/assets/57502434/f9310418-d401-4791-8938-79c1c0ba80ec)
Old Behaviour

![image](https://github.com/digabi/koe-ohje/assets/57502434/05710be9-c040-4850-b589-fffd869f29dd)
New Behaviour

![image](https://github.com/digabi/koe-ohje/assets/57502434/300c8c37-34e0-44a7-8365-fc8f1215e744)
Console Behaviour
</details>
<details>
<summary>Program output swallowed by exception (#692)</summary>
<br />

> [!NOTE]
> The messed up exceptions are a bug/feature with boilerplate error string removal, but was left as is as it was out of the scope of this PR. I can fix this in another PR if needed.

![image](https://github.com/digabi/koe-ohje/assets/57502434/cfb7be97-28aa-471a-ad0a-ee39217e7ed4)
Old Behaviour

![image](https://github.com/digabi/koe-ohje/assets/57502434/568e4171-114a-497d-9b3e-e099aa63f732)
New Behaviour

![image](https://github.com/digabi/koe-ohje/assets/57502434/13ca42a9-6314-421a-883e-18f932ece72e)
Console Behaviour
</details>
<details>
<summary>Error swallowed by program output (#692)</summary>

![image](https://github.com/digabi/koe-ohje/assets/57502434/0b27c3e8-58eb-4773-bf27-7e12ad06a9a7)
Old Behaviour

![image](https://github.com/digabi/koe-ohje/assets/57502434/d298dad6-9c36-43bf-acb4-3342b159cb26)
New Behaviour

![image](https://github.com/digabi/koe-ohje/assets/57502434/6e7b1fa7-3136-4e57-bc8d-62495880802f)
Console Behaviour
</details>

### New behavioural changes
<details>
<summary>Switch input() prompt from __repr__ to __str__</summary>

![image](https://github.com/digabi/koe-ohje/assets/57502434/ebd86cb4-6d13-4ad2-b4ea-5a49ab7fd137)
Old Behaviour

![image](https://github.com/digabi/koe-ohje/assets/57502434/0c17aab8-3036-4ca5-8581-7347327a5758)
New Behaviour

![image](https://github.com/digabi/koe-ohje/assets/57502434/5349be21-a088-423b-878b-6ddd90fce297)
Console Behaviour
</details>
<details>
<summary>Raise exception if input() cannot return a str object</summary>

![image](https://github.com/digabi/koe-ohje/assets/57502434/f1d35147-a88e-457e-ba9e-c0586af29e62)
Old Behaviour

![image](https://github.com/digabi/koe-ohje/assets/57502434/c4bbeb24-9247-4019-83f7-594ec1d8e1d0)
New Behaviour

<details>
<summary>How input's behaviour is documented</summary>

![image](https://github.com/digabi/koe-ohje/assets/57502434/527dc0b2-e4bc-499e-8a96-6571b752e9b0)
</details>

As you cannot cancel the input operation on Console, we cannot really compare our behaviour to it. Instead we must compare it to the documented behaviour. While cancelling the operation isn't documented, I felt that raising an exception was the more sane option since type checkers such as Pyright (see below) define that an input must only return an object of type `str`.
![image](https://github.com/digabi/koe-ohje/assets/57502434/5948ae29-bd28-4929-981a-25be1943b452)
> [!NOTE]
> We do not completely implement the `input()` spec as we do not raise the documented [auditing events](https://docs.python.org/3/library/audit_events.html#audit-events). This can be implemented in another PR if necessary, but was purposefully left out as it has such a niche usage, but would require extensive testing, for which I don't really have the resources right now.

</details>

## Unresolved Problems
### Accessibility
While I tried to retain the accessibility of the code editor, I am not certain whether everything is in order since I've never really programmed anything accessibility related before and my familiarity with this codebase isn't the best.

### Tests
I wasn't able to run the provided Makefile or build the source successfully (I'm on Windows and the build tools seem to be have been made primarily for Linux) which means that I was implementing these features on a broken build. Due to this, I was not able to run any tests. These tests need to be rewritten due to the changes made to the code output, but as I can't run them, it wouldn't be wise to even try to write the tests myself.
If anyone who can get a working build of this repo would be able to write these tests, it would be massively appreciated.
As I wasn't able to run the Makefile, Pyodide needs to be updated by someone else as well if a new version is available.

While I'm very certain that I have tested all possible scenarios by hand, I cannot guarantee that this implementation is 100 % stable as my build was still broken. See below for what I mean by not being certain of 100 % stability.

### Unknown Error
For some reason, I get spammed with errors every time I try to resize the code editor, but I decided to ignore this as it happens to me on earlier versions of koe-ohje as well.
This might just be an issue on my side as I wasn't able to compile the source successfully.