### PR TITLE
Prevent console error when quickly visiting programming tab

### DIFF
--- a/src/tabs/programming.ts
+++ b/src/tabs/programming.ts
@@ -24,6 +24,7 @@ const boilerplateErrorstrings = [
 
 let pyodide: any = null
 let pyodideInitializing = true
+let programmingTabActive = false
 
 const isSingleColumn = () => window.innerWidth / 2 <= document.getElementById(codeEditorWrapperId).offsetWidth
 
@@ -68,6 +69,9 @@ const showErrorArea = () => {
 }
 
 const showOutputArea = () => {
+  if (!programmingTabActive) {
+    return
+  }
   document.getElementById(outputId).style.display = 'block'
   document.getElementById(errorId).style.display = 'none'
 
@@ -252,6 +256,7 @@ const processAccessibilityKeybindings = (event: KeyboardEvent) => {
 }
 
 export const initializeProgrammingTab = () => {
+  programmingTabActive = true
   const monacoExitAction = (actionType: string) => {
     focusButtonExecuteCode()
   }
@@ -269,5 +274,6 @@ export const initializeProgrammingTab = () => {
 }
 
 export const teardownProgrammingTab = () => {
+  programmingTabActive = false
   document.removeEventListener('keydown', processAccessibilityKeybindings)
 }


### PR DESCRIPTION
- The following error is caused by showOutputArea in console if user initializes programming tab and quickly changes to another tab before pyodide is ready: "TypeError: Cannot read properties of null (reading 'style')"

- The reason for the error is that when the user navigated to a new tab the div code-output was removed and showOutputArea tries to set the div style after it has been removed.