### PR TITLE
Revert "Use special base url in Abitti2"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY package-lock.json .
 COPY package.json .
 RUN npm ci
 COPY . .
-RUN npm run build:a2
+RUN npm run build
 
 FROM nginx:alpine as prod
 COPY --from=builder /app/build /usr/share/nginx/html/build

--- a/esbuild.ts
+++ b/esbuild.ts
@@ -1,12 +1,11 @@
 // eslint-disable-next-line
 const esbuild = require('esbuild')
 
-const isWatchMode = process.argv.includes('--watch')
+const isWatchMode = process.argv.includes("--watch")
 
 /* `koe` build version is the one to be run in actual test environment,
  * the `else` option is the cheat app hosted in S3 for public internet usage */
 const isKoeBuild = process.env.DEPLOYMENT_ENV === 'koe'
-const isA2Build = process.env.DEPLOYMENT_ENV === 'a2'
 
 const buildOptions = {
   entryPoints: [{ in: './src/index.ts', out: 'app.bundle' }],
@@ -18,16 +17,17 @@ const buildOptions = {
     '.png': 'file',
     '.gif': 'file',
     '.ttf': 'file',
+
   },
   define: {
     'process.env.ABICODE_URL': isKoeBuild ? JSON.stringify('') : JSON.stringify('https://abicode.abitti.fi'),
-    'process.env.MAP_TILES_URL': isKoeBuild
-      ? JSON.stringify('/tiles')
-      : isA2Build
-        ? JSON.stringify('/apps/cheat/tiles')
+    'process.env.MAP_TILES_URL':
+      isKoeBuild
+        ? JSON.stringify('/tiles')
         : JSON.stringify('https://s3.eu-north-1.amazonaws.com/abitti-prod.abitti-prod-cdk.maptiles.abitti.fi'),
-    'process.env.MATH_DEMO_URL': isKoeBuild ? JSON.stringify('') : JSON.stringify('https://math-demo.abitti.fi'),
-    'process.env.WATCH': isWatchMode.toString(),
+    'process.env.MATH_DEMO_URL':
+      isKoeBuild ? JSON.stringify('') : JSON.stringify('https://math-demo.abitti.fi'),
+    'process.env.WATCH': isWatchMode.toString()
   },
 }
 
@@ -37,8 +37,8 @@ const watch = async () => {
   await buildContext.watch()
 
   await buildContext.serve({
-    servedir: '.',
-    port: 8080,
+    servedir: ".",
+    port: 8080
   })
   console.log('Watching for changes, serving in port 8080.')
 }
@@ -46,8 +46,5 @@ const watch = async () => {
 if (isWatchMode) {
   watch().catch(console.error)
 } else {
-  esbuild
-    .build(buildOptions)
-    .then(() => console.log('esbuild done'))
-    .catch(console.error)
+  esbuild.build(buildOptions).then(() => console.log('esbuild done')).catch(console.error)
 }

--- a/esbuild.ts
+++ b/esbuild.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line
 const esbuild = require('esbuild')
 
-const isWatchMode = process.argv.includes("--watch")
+const isWatchMode = process.argv.includes('--watch')
 
 /* `koe` build version is the one to be run in actual test environment,
  * the `else` option is the cheat app hosted in S3 for public internet usage */
@@ -17,17 +17,14 @@ const buildOptions = {
     '.png': 'file',
     '.gif': 'file',
     '.ttf': 'file',
-
   },
   define: {
     'process.env.ABICODE_URL': isKoeBuild ? JSON.stringify('') : JSON.stringify('https://abicode.abitti.fi'),
-    'process.env.MAP_TILES_URL':
-      isKoeBuild
-        ? JSON.stringify('/tiles')
-        : JSON.stringify('https://s3.eu-north-1.amazonaws.com/abitti-prod.abitti-prod-cdk.maptiles.abitti.fi'),
-    'process.env.MATH_DEMO_URL':
-      isKoeBuild ? JSON.stringify('') : JSON.stringify('https://math-demo.abitti.fi'),
-    'process.env.WATCH': isWatchMode.toString()
+    'process.env.MAP_TILES_URL': isKoeBuild
+      ? JSON.stringify('/tiles')
+      : JSON.stringify('https://s3.eu-north-1.amazonaws.com/abitti-prod.abitti-prod-cdk.maptiles.abitti.fi'),
+    'process.env.MATH_DEMO_URL': isKoeBuild ? JSON.stringify('') : JSON.stringify('https://math-demo.abitti.fi'),
+    'process.env.WATCH': isWatchMode.toString(),
   },
 }
 
@@ -37,8 +34,8 @@ const watch = async () => {
   await buildContext.watch()
 
   await buildContext.serve({
-    servedir: ".",
-    port: 8080
+    servedir: '.',
+    port: 8080,
   })
   console.log('Watching for changes, serving in port 8080.')
 }
@@ -46,5 +43,8 @@ const watch = async () => {
 if (isWatchMode) {
   watch().catch(console.error)
 } else {
-  esbuild.build(buildOptions).then(() => console.log('esbuild done')).catch(console.error)
+  esbuild
+    .build(buildOptions)
+    .then(() => console.log('esbuild done'))
+    .catch(console.error)
 }

--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@ mod? digabi2-companion-app
 
 gh := require("gh")
 jq := require("jq")
+git-lfs := require("git-lfs")
 
 build: fetch
     if [[ ! -d "map-tiles" ]]; then gh repo clone digabi/map-tiles; fi

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "index.js",
   "scripts": {
     "build": "node index.js && DEPLOYMENT_ENV=koe node --experimental-strip-types esbuild.ts",
-    "build:a2": "node index.js && DEPLOYMENT_ENV=a2 node --experimental-strip-types esbuild.ts",
     "build:internet": "node index.js && node --experimental-strip-types esbuild.ts",
     "watch": "node --experimental-strip-types esbuild.ts --watch",
     "lint": "eslint . --ext .ts,.js",


### PR DESCRIPTION
This reverts commit a87d812bd95aafcc53a94c8d4abf2ba49506e0d1. 
A2 doesn't require special MAP_TILES_URL anymore.
Also require git-lfs in justfile as it is needed to fetch the tiles. 