### PR TITLE
skip front page if language is selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,7 @@
         const lang = params.get('lang')
 
         if (lang) {
-          const searchString = window.location.search
-          const finalLang = searchString.includes('sv') ? 'sv' : 'fi'
+          const finalLang = lang.includes('sv') ? 'sv' : 'fi'
           window.location.href = `build/index.html?lang=${finalLang}`
         }
       }

--- a/index.html
+++ b/index.html
@@ -20,6 +20,19 @@
         })
       }
 
+      function checkLanguageRedirect() {
+        const params = new URLSearchParams(window.location.search)
+        const lang = params.get('lang')
+
+        if (lang) {
+          const searchString = window.location.search
+          const finalLang = searchString.includes('sv') ? 'sv' : 'fi'
+          window.location.href = `build/index.html?lang=${finalLang}`
+        }
+      }
+
+      checkLanguageRedirect()
+
     </script>
   </head>
   <body onLoad="addTabParameter()">


### PR DESCRIPTION
this fixes a regression that happened because of A1 removal.

abittiVersion-param redirect check was removed, however it was doing the "skip language selection" feature in abitti

here I return the functionality but without abittiVersion